### PR TITLE
Make Arr::forget() support wildcards

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -256,7 +256,17 @@ class Arr
             while (count($parts) > 1) {
                 $part = array_shift($parts);
 
-                if (isset($array[$part]) && is_array($array[$part])) {
+                if ($part === '*') {
+                    foreach ($array as &$item) {
+                        if (!is_array($item)) {
+                            // to unset an array item's key that item must itself be an array
+                            continue;
+                        }
+
+                        // we need to join the parts togetehr again since it's still a single key that needs forgetting
+                        static::forget($item, implode('.', $parts));
+                    }
+                } elseif (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
                 } else {
                     continue 2;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -604,53 +604,82 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['10' => 1, 20 => 2], $array);
     }
 
-    public function testForget()
+    /**
+     * @dataProvider providerTestForget
+     */
+    public function testForget(array $array, $keys, array $expectedArray)
     {
-        $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::forget($array, null);
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+        Arr::forget($array, $keys);
+        $this->assertEquals($expectedArray, $array);
+    }
 
-        $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::forget($array, []);
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+    public function providerTestForget()
+    {
+        return [
+            [
+                ['products' => ['desk' => ['price' => 100]]],
+                null,
+                ['products' => ['desk' => ['price' => 100]]]
+            ],
+            [
+                ['products' => ['desk' => ['price' => 100]]],
+                [],
+                ['products' => ['desk' => ['price' => 100]]]
 
-        $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::forget($array, 'products.desk');
-        $this->assertEquals(['products' => []], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => 100]]],
+                'products.desk',
+                ['products' => []]
 
-        $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::forget($array, 'products.desk.price');
-        $this->assertEquals(['products' => ['desk' => []]], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => 100]]],
+                'products.desk.price',
+                ['products' => ['desk' => []]]
 
-        $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::forget($array, 'products.final.price');
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => 100]]],
+                'products.final.price',
+                ['products' => ['desk' => ['price' => 100]]]
 
-        $array = ['shop' => ['cart' => [150 => 0]]];
-        Arr::forget($array, 'shop.final.cart');
-        $this->assertEquals(['shop' => ['cart' => [150 => 0]]], $array);
+            ],
+            [
+                ['shop' => ['cart' => [150 => 0]]],
+                'shop.final.cart',
+                ['shop' => ['cart' => [150 => 0]]]
 
-        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
-        Arr::forget($array, 'products.desk.price.taxes');
-        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50]]]], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]],
+                'products.desk.price.taxes',
+                ['products' => ['desk' => ['price' => ['original' => 50]]]]
 
-        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
-        Arr::forget($array, 'products.desk.final.taxes');
-        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]],
+                'products.desk.final.taxes',
+                ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]]
 
-        $array = ['products' => ['desk' => ['price' => 50], null => 'something']];
-        Arr::forget($array, ['products.amount.all', 'products.desk.price']);
-        $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
+            ],
+            [
+                ['products' => ['desk' => ['price' => 50], null => 'something']],
+                ['products.amount.all', 'products.desk.price'],
+                ['products' => ['desk' => [], null => 'something']]
 
-        // Only works on first level keys
-        $array = ['joe@example.com' => 'Joe', 'jane@example.com' => 'Jane'];
-        Arr::forget($array, 'joe@example.com');
-        $this->assertEquals(['jane@example.com' => 'Jane'], $array);
-
-        // Does not work for nested keys
-        $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
-        Arr::forget($array, ['emails.joe@example.com', 'emails.jane@localhost']);
-        $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
+            ],
+            'Only works on first level keys' => [
+                ['joe@example.com' => 'Joe', 'jane@example.com' => 'Jane'],
+                'joe@example.com',
+                ['jane@example.com' => 'Jane']
+            ],
+            'Does not work for nested keys' => [
+                ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]],
+                ['emails.joe@example.com', 'emails.jane@localhost'],
+                ['emails' => ['joe@example.com' => ['name' => 'Joe']]]
+            ]
+        ];
     }
 
     public function testWrap()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -678,6 +678,146 @@ class SupportArrTest extends TestCase
                 ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]],
                 ['emails.joe@example.com', 'emails.jane@localhost'],
                 ['emails' => ['joe@example.com' => ['name' => 'Joe']]]
+            ],
+            'With Wildcard' => [
+                [
+                    'email' => [
+                        'id' => 1,
+                        'email' => 'joe@example.com'
+                    ],
+                    'address' => [
+                        'id' => 2,
+                        'address' => 'North St'
+                    ]
+                ],
+                '*.id',
+                [
+                    'email' => [
+                        'email' => 'joe@example.com'
+                    ],
+                    'address' => [
+                        'address' => 'North St'
+                    ]
+                ]
+            ],
+            'With several Wildcards' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost'
+                        ]
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St'
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St'
+                        ]
+                    ]
+                ],
+                '*.*.id',
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'email' => 'jane@localhost'
+                        ]
+                    ],
+                    'addresses' => [
+                        [
+                            'address' => 'North St'
+                        ],
+                        [
+                            'address' => 'South St'
+                        ]
+                    ]
+                ]
+            ],
+            'With several keys, one of which has a wildcard' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost'
+                        ]
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St'
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St'
+                        ]
+                    ]
+                ],
+                ['*.*.id', 'addresses'],
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'email' => 'jane@localhost'
+                        ]
+                    ]
+                ]
+            ],
+            'With several keys with Wildcards' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost'
+                        ]
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St'
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St'
+                        ]
+                    ]
+                ],
+                ['*.*.id', 'addresses.*.address'],
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com'
+                        ],
+                        [
+                            'email' => 'jane@localhost'
+                        ]
+                    ],
+                    'addresses' => [
+                        [
+                        ],
+                        [
+                        ]
+                    ]
+                ]
             ]
         ];
     }


### PR DESCRIPTION
I needed `Arr:forget()` to support wildcards so I added it.

Eg. given the following array:

```php
[
    'email' => [
        'id' => 1,
        'email' => 'joe@example.com'
    ],
    'address' => [
        'id' => 2,
        'address' => 'North St'
    ]
]
```

Running `Arr::forget($array, '*.id')` will transform the array into:
```php
[
    'email' => [
        'email' => 'joe@example.com'
    ],
    'address' => [
        'address' => 'North St'
    ]
]
```

While writing a test for this I also took the opportunity to improve the existing `SupportArrTest::testForget()` so it uses a provider.