### PR TITLE
Make Arr::forget() support wildcards

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -256,7 +256,17 @@ class Arr
             while (count($parts) > 1) {
                 $part = array_shift($parts);
 
-                if (isset($array[$part]) && is_array($array[$part])) {
+                if ($part === '*') {
+                    foreach ($array as &$item) {
+                        if (! is_array($item)) {
+                            // to unset an array item's key that item must itself be an array
+                            continue;
+                        }
+
+                        // we need to join the parts togetehr again since it's still a single key that needs forgetting
+                        static::forget($item, implode('.', $parts));
+                    }
+                } elseif (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
                 } else {
                     continue 2;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -661,6 +661,161 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
     }
 
+    /**
+     * @dataProvider providerTestForgetWithWildcards
+     */
+    public function testForgetWithWildcards(array $array, $keys, array $expectedArray)
+    {
+        Arr::forget($array, $keys);
+        $this->assertEquals($expectedArray, $array);
+    }
+
+    public function providerTestForgetWithWildcards()
+    {
+        return [
+            'With Wildcard' => [
+                [
+                    'email' => [
+                        'id' => 1,
+                        'email' => 'joe@example.com',
+                    ],
+                    'address' => [
+                        'id' => 2,
+                        'address' => 'North St',
+                    ],
+                ],
+                '*.id',
+                [
+                    'email' => [
+                        'email' => 'joe@example.com',
+                    ],
+                    'address' => [
+                        'address' => 'North St',
+                    ],
+                ],
+            ],
+            'With several Wildcards' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St',
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St',
+                        ],
+                    ],
+                ],
+                '*.*.id',
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                    'addresses' => [
+                        [
+                            'address' => 'North St',
+                        ],
+                        [
+                            'address' => 'South St',
+                        ],
+                    ],
+                ],
+            ],
+            'With several keys, one of which has a wildcard' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St',
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St',
+                        ],
+                    ],
+                ],
+                ['*.*.id', 'addresses'],
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                ],
+            ],
+            'With several keys with Wildcards' => [
+                [
+                    'emails' => [
+                        [
+                            'id' => 1,
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'id' => 2,
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                    'addresses' => [
+                        [
+                            'id' => 1,
+                            'address' => 'North St',
+                        ],
+                        [
+                            'id' => 2,
+                            'address' => 'South St',
+                        ],
+                    ],
+                ],
+                ['*.*.id', 'addresses.*.address'],
+                [
+                    'emails' => [
+                        [
+                            'email' => 'joe@example.com',
+                        ],
+                        [
+                            'email' => 'jane@localhost',
+                        ],
+                    ],
+                    'addresses' => [
+                        [
+                        ],
+                        [
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
     public function testWrap()
     {
         $string = 'a';


### PR DESCRIPTION
I needed `Arr:forget()` to support wildcards so I added it.

Eg. given the following array:

```php
[
    'email' => [
        'id' => 1,
        'email' => 'joe@example.com'
    ],
    'address' => [
        'id' => 2,
        'address' => 'North St'
    ]
]
```

Running `Arr::forget($array, '*.id')` will transform the array into:
```php
[
    'email' => [
        'email' => 'joe@example.com'
    ],
    'address' => [
        'address' => 'North St'
    ]
]
```

**Backwards compatibility:** will change code that forgets a key named exactly `*`.